### PR TITLE
Repeatable form bugfix

### DIFF
--- a/redux-form-tutorial/src/main/typescript/components/RepeatableForm.tsx
+++ b/redux-form-tutorial/src/main/typescript/components/RepeatableForm.tsx
@@ -1,10 +1,10 @@
 import * as React from "react"
 import { Component } from "react"
-import { Field, FieldArray, InjectedFormProps, reduxForm, WrappedFieldArrayProps, } from "redux-form"
+import { Field, InjectedFormProps, reduxForm, } from "redux-form"
 import { Dispatch } from "../util"
 import { AppState } from "../model/AppState"
 import { connect } from "react-redux"
-import { createRepeatedRender, RenderInput } from "../lib/form"
+import { createRepeatedRender, RenderInput, RepeatableField } from "../lib/form"
 
 const isRequired = (errorText: string) => (value?: any) => value ? undefined : errorText
 const required = isRequired("Required")
@@ -60,32 +60,11 @@ class RepeatableForm extends Component<AllRepeatableFormProps> {
                    label="Club Name"
                    component={RenderInput}
                    validate={[required]}/>
-            <FieldArray name="members"
-                        label="Add Member"
-                        component={RepeatableMember}
-                        empty={{}}
-                        validate={[nonEmptyList]}/>
-            {/* TODO remove the FieldArray below. That one is just for testing! */}
-            <FieldArray name="members"
-                        component={(props: WrappedFieldArrayProps<{foo: boolean}> & {label: string, empty: any}) => {
-                            console.log(props)
-
-                            return (
-                                <>
-                                    <h1>hello</h1>
-                                    <ul>{props.fields.map((x, index) => {
-                                        console.log("x", x)
-                                        return <li key={index}>{x}</li>
-                                    })}</ul>
-                                    <button onClick={() => {
-                                        props.fields.push({foo: true})
-                                        props.fields.push({foo: false})
-                                    }}>click me</button>
-                                </>
-                            )
-                        }}
-                        label="Add Member"
-                        empty={{}}/>
+            <RepeatableField name="members"
+                             label="Add Member"
+                             component={RepeatableMember}
+                             empty={{}}
+                             validate={[nonEmptyList]}/>
 
             <button type="submit" disabled={this.props.submitting}>Submit</button>
         </form>

--- a/redux-form-tutorial/src/main/typescript/components/RepeatableForm.tsx
+++ b/redux-form-tutorial/src/main/typescript/components/RepeatableForm.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import {Component} from 'react'
-import {Field, FieldArray, InjectedFormProps, reduxForm} from "redux-form"
-import {Dispatch} from "../util"
-import {AppState} from "../model/AppState"
-import {connect} from "react-redux"
-import {createRepeatedRender, RenderInput} from "../lib/form"
+import * as React from "react"
+import { Component } from "react"
+import { Field, FieldArray, InjectedFormProps, reduxForm, WrappedFieldArrayProps, } from "redux-form"
+import { Dispatch } from "../util"
+import { AppState } from "../model/AppState"
+import { connect } from "react-redux"
+import { createRepeatedRender, RenderInput } from "../lib/form"
 
 const isRequired = (errorText: string) => (value?: any) => value ? undefined : errorText
 const required = isRequired("Required")
@@ -26,7 +26,7 @@ interface RepeatableFormProps {
 
 type AllRepeatableFormProps = RepeatableFormProps & InjectedFormProps<RepeatableFormData>
 
-const RepeatableMember = createRepeatedRender((name, index, fields) => {
+const RepeatableMember = createRepeatedRender<MemberData>((name, index, fields) => {
     return <div key={index}>
         <button
             type="button"
@@ -65,6 +65,27 @@ class RepeatableForm extends Component<AllRepeatableFormProps> {
                         component={RepeatableMember}
                         empty={{}}
                         validate={[nonEmptyList]}/>
+            {/* TODO remove the FieldArray below. That one is just for testing! */}
+            <FieldArray name="members"
+                        component={(props: WrappedFieldArrayProps<{foo: boolean}> & {label: string, empty: any}) => {
+                            console.log(props)
+
+                            return (
+                                <>
+                                    <h1>hello</h1>
+                                    <ul>{props.fields.map((x, index) => {
+                                        console.log("x", x)
+                                        return <li key={index}>{x}</li>
+                                    })}</ul>
+                                    <button onClick={() => {
+                                        props.fields.push({foo: true})
+                                        props.fields.push({foo: false})
+                                    }}>click me</button>
+                                </>
+                            )
+                        }}
+                        label="Add Member"
+                        empty={{}}/>
 
             <button type="submit" disabled={this.props.submitting}>Submit</button>
         </form>

--- a/redux-form-tutorial/src/main/typescript/lib/form.tsx
+++ b/redux-form-tutorial/src/main/typescript/lib/form.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { WrappedFieldArrayProps, WrappedFieldInputProps } from "redux-form"
+import { FieldArray, GenericFieldArray, WrappedFieldArrayProps, WrappedFieldInputProps } from "redux-form"
 import { WrappedFieldProps } from "redux-form/lib/Field"
 import DatePicker from "react-datepicker"
 import * as moment from "moment"
@@ -104,6 +104,8 @@ export const RenderComposed = createRenderer((input, label, {children}) => <div 
 // repeatable elements
 type FieldArrayProps<FieldValue> = WrappedFieldArrayProps<FieldValue>
     & { label: string, empty: FieldValue }
+
+export const RepeatableField = FieldArray as new <Data>() => GenericFieldArray<Data, { label: string, empty: Data }>;
 
 export function createRepeatedRender<Data>(renderer: FieldIterate<Data, JSX.Element>) {
     return (props: FieldArrayProps<Data>) => {

--- a/redux-form-tutorial/src/main/typescript/lib/form.tsx
+++ b/redux-form-tutorial/src/main/typescript/lib/form.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import {BaseFieldArrayProps, WrappedFieldArrayProps, WrappedFieldInputProps} from "redux-form"
-import {BaseFieldProps, WrappedFieldProps} from "redux-form/lib/Field"
-import DatePicker from 'react-datepicker'
+import * as React from "react"
+import { WrappedFieldArrayProps, WrappedFieldInputProps } from "redux-form"
+import { WrappedFieldProps } from "redux-form/lib/Field"
+import DatePicker from "react-datepicker"
 import * as moment from "moment"
-import {Moment} from "moment"
-import {FieldIterate} from "redux-form/lib/FieldArray"
+import { Moment } from "moment"
+import { FieldIterate } from "redux-form/lib/FieldArray"
 
-type FieldProps = WrappedFieldProps & BaseFieldProps & { required?: boolean }
+type FieldProps = WrappedFieldProps & { required?: boolean }
 type renderer = (input: WrappedFieldInputProps, label?: string, rest?: any) => JSX.Element
 
 function createRenderer<T>(renderer: renderer) {
@@ -103,13 +103,10 @@ export const RenderComposed = createRenderer((input, label, {children}) => <div 
 
 // repeatable elements
 type FieldArrayProps<FieldValue> = WrappedFieldArrayProps<FieldValue>
-    & BaseFieldArrayProps<FieldValue>
     & { label: string, empty: FieldValue }
 
 export function createRepeatedRender<Data>(renderer: FieldIterate<Data, JSX.Element>) {
-    // TODO we can't provide the type here. Awaiting https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23592
-    // to be resolved. Once changed, turn '"noImplicitAny": true' in tsconfig.json back on!
-    return (props/*: FieldArrayProps<Data>*/) => {
+    return (props: FieldArrayProps<Data>) => {
         const {fields, meta: {error, submitFailed}, label, empty} = props
         const hasError = error && submitFailed
 

--- a/redux-form-tutorial/tsconfig.json
+++ b/redux-form-tutorial/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "sourceMap": true,
-//    "noImplicitAny": true,
+    "noImplicitAny": true,
     "strictNullChecks": true,
     "module": "es2015",
     "target": "es6",


### PR DESCRIPTION
Solved the issue with `redux-form`'s `FieldArray`. This issue made me use `"noImplicitAny": false` in `tsconfig.json`, to avoid compile errors on the `FieldArray`.

The solution mainly consists of introducing our own definition of `FieldArray` using it's supertype `GenericFieldArray`. For now this suffices our needs.
https://github.com/Dans-labs/electron-experiments/blob/952ec9232c020dfd67f2061dc147c53b45ebd939/redux-form-tutorial/src/main/typescript/lib/form.tsx#L108

Usage: https://github.com/Dans-labs/electron-experiments/blob/952ec9232c020dfd67f2061dc147c53b45ebd939/redux-form-tutorial/src/main/typescript/components/RepeatableForm.tsx#L63-L67